### PR TITLE
cueobserve#158 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ docker run -p 3000:3000 cuebook/cueobserve
 ```
 docker-compose up -d
 ```
+**Or** build from codebase via docker-compose **in development environment**:
+```
+docker-compose -f docker-compose-dev.yml up -d
+```
 Now visit [http://localhost:3000](http://localhost:3000) in your browser. 
 
 ## Demo Video

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y gnupg2 curl
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
 RUN apt-get update && ACCEPT_EULA=Y apt-get install -y --no-install-recommends unixodbc msodbcsql17 mssql-tools unixodbc-dev
-RUN apt-get install -y --no-install-recommends redis-server nginx default-libmysqlclient-dev
+RUN apt-get install -y --no-install-recommends nginx default-libmysqlclient-dev
 
 WORKDIR /code
 

--- a/api/start_server_new.sh
+++ b/api/start_server_new.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # start-server.sh
-redis-server &
 export DEBUG=false
 python manage.py migrate
 python manage.py loaddata seeddata/*.json
@@ -13,7 +12,6 @@ python ./manage.py collectstatic
 mkdir -p /home/staticfiles
 mv static_root/* /home/staticfiles
 rm -rf static_root/
-(/usr/bin/redis-server) &
 (celery -A app worker --concurrency=2 -l INFO --purge) &
 (celery -A app worker --concurrency=4 -Q anomalySubTask -l INFO --purge) &
 (celery -A app beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler) &

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -26,13 +26,16 @@ services:
       context: alerts-api
       dockerfile: Dockerfile
     volumes:
-      - ${PWD}/alerts-api:/code:rw
+      - ./alerts-api:/code:rw
     network_mode: "host"
 
   cueo-frontend:
     build:
       context: ui
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
+    stdin_open: true
+    volumes:
+      - ./ui/src:/app/src:rw
     network_mode: "host"
 
   cueo-postgresql:
@@ -49,14 +52,6 @@ services:
   cueo-redis:
     image: redis
     network_mode: "host"
-
-
-networks:
-  external-network:
-    external:
-      name: nginx-web
-  cue-network:
-    internal: true
 
 volumes:
   pgdata:

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,7 +1,7 @@
 # Build frontend
 FROM node:12-slim as builder
 
-WORKDIR /usr/src/app
+WORKDIR /app
 COPY package.json ./
 RUN yarn install --silent
 COPY . ./

--- a/ui/Dockerfile.dev
+++ b/ui/Dockerfile.dev
@@ -1,0 +1,9 @@
+# Build frontend
+FROM node:12-slim as builder
+
+WORKDIR /app
+COPY package.json ./
+RUN yarn install --silent
+COPY . ./
+EXPOSE 3000
+CMD ["yarn", "start"]


### PR DESCRIPTION
1) docker-compose-dev created for faster local development, 2) redis converted to a service, 3) environment variables are not automatically used in docker-compose, 4) unnecessary files removed